### PR TITLE
The option to throw exception after logging.error call

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,6 +19,8 @@ DEFAULT_ALIAS_FEE = 100000
 VALID_TIMEFRAMES = (5, 15, 30, 60, 240, 1440)
 MAX_WDF_REQUEST = 100
 
+THROW_EXCEPTION_ON_ERROR = False
+
 import requests
 
 from .address import *
@@ -40,6 +42,20 @@ console.setLevel(logging.ERROR)
 formatter = logging.Formatter('[%(levelname)s] %(message)s')
 console.setFormatter(formatter)
 logging.getLogger('').addHandler(console)
+
+
+class PyWawesException(ValueError):
+    pass
+
+
+def throw_error(msg):
+    if THROW_EXCEPTION_ON_ERROR:
+        raise PyWawesException(msg)
+
+
+def setThrowOnError(throw=True):
+    global THROW_EXCEPTION_ON_ERROR
+    THROW_EXCEPTION_ON_ERROR = throw
 
 
 def setOffline():

--- a/address.py
+++ b/address.py
@@ -287,9 +287,13 @@ class Address(object):
 
     def issueAsset(self, name, description, quantity, decimals=0, reissuable=False, txFee=pywaves.DEFAULT_ASSET_FEE):
         if not self.privateKey:
-            logging.error('Private key required')
+            msg = 'Private key required'
+            logging.error(msg)
+            pywaves.throw_error(msg)
         elif len(name) < 4 or len(name) > 16:
-            logging.error('Asset name must be between 4 and 16 characters long')
+            msg = 'Asset name must be between 4 and 16 characters long'
+            logging.error(msg)
+            pywaves.throw_error(msg)
         else:
             timestamp = int(time.time() * 1000)
             sData = b'\3' + \
@@ -371,11 +375,19 @@ class Address(object):
 
     def sendWaves(self, recipient, amount, attachment='', txFee=pywaves.DEFAULT_TX_FEE, timestamp=0):
         if not self.privateKey:
-            logging.error('Private key required')
+            msg = 'Private key required'
+            logging.error(msg)
+            pywaves.throw_error(msg)
+
         elif amount <= 0:
-            logging.error('Amount must be > 0')
+            msg = 'Amount must be > 0'
+            logging.error(msg)
+            pywaves.throw_error(msg)
         elif not pywaves.OFFLINE and self.balance() < amount + txFee:
-            logging.error('Insufficient Waves balance')
+            msg = 'Insufficient Waves balance'
+            logging.error(msg)
+            pywaves.throw_error(msg)
+
         else:
             if timestamp == 0:
                 timestamp = int(time.time() * 1000)
@@ -402,15 +414,25 @@ class Address(object):
 
     def sendAsset(self, recipient, asset, amount, attachment='', txFee=pywaves.DEFAULT_TX_FEE, timestamp=0):
         if not self.privateKey:
-            logging.error('Private key required')
+            msg = 'Private key required'
+            logging.error(msg)
+            pywaves.throw_error(msg)
         elif not pywaves.OFFLINE and not asset.status():
-            logging.error('Asset not issued')
+            msg = 'Asset not issued'
+            logging.error(msg)
+            pywaves.throw_error(msg)
         elif amount <= 0:
-            logging.error('Amount must be > 0')
+            msg = 'Amount must be > 0'
+            logging.error(msg)
+            pywaves.throw_error(msg)
         elif not pywaves.OFFLINE and self.balance(asset.assetId) < amount:
-            logging.error('Insufficient asset balance')
+            msg = 'Insufficient asset balance'
+            logging.error(msg)
+            pywaves.throw_error(msg)
         elif not pywaves.OFFLINE and self.balance() < txFee:
-            logging.error('Insufficient Waves balance')
+            msg = 'Insufficient Waves balance'
+            logging.error(msg)
+            pywaves.throw_error(msg)
         else:
             if timestamp == 0:
                 timestamp = int(time.time() * 1000)
@@ -475,12 +497,15 @@ class Address(object):
         id = -1
         if 'status' in req:
             if req['status'] == 'OrderRejected':
-                logging.error('Order Rejected - %s' % req['message'])
+                msg = 'Order Rejected - %s' % req['message']
+                logging.error(msg)
+                pywaves.throw_error(msg)
             elif req['status'] == 'OrderAccepted':
                 id = req['message']['id']
                 logging.info('Order Accepted - ID: %s' % id)
         elif not pywaves.OFFLINE:
             logging.error(req)
+            pywaves.throw_error(req)
         else:
             return req
         return id
@@ -488,9 +513,14 @@ class Address(object):
     def cancelOrder(self, assetPair, order):
         if not pywaves.OFFLINE:
             if order.status() == 'Filled':
-                logging.error("Order already filled")
+                msg = "Order already filled"
+                logging.error(msg)
+                pywaves.throw_error(msg)
+
             elif not order.status():
-                logging.error("Order not found")
+                msg = "Order not found"
+                logging.error(msg)
+                pywaves.throw_error(msg)
         sData = base58.b58decode(self.publicKey) + \
                 base58.b58decode(order.orderId)
         signature = crypto.sign(self.privateKey, sData)
@@ -561,11 +591,17 @@ class Address(object):
 
     def lease(self, recipient, amount, txFee=pywaves.DEFAULT_LEASE_FEE, timestamp=0):
         if not self.privateKey:
-            logging.error('Private key required')
+            msg = 'Private key required'
+            logging.error(msg)
+            pywaves.throw_error(msg)
         elif amount <= 0:
-            logging.error('Amount must be > 0')
+            msg = 'Amount must be > 0'
+            logging.error(msg)
+            pywaves.throw_error(msg)
         elif not pywaves.OFFLINE and self.balance() < amount + txFee:
-            logging.error('Insufficient Waves balance')
+            msg = 'Insufficient Waves balance'
+            logging.error(msg)
+            pywaves.throw_error(msg)
         else:
             if timestamp == 0:
                 timestamp = int(time.time() * 1000)
@@ -592,9 +628,13 @@ class Address(object):
 
     def leaseCancel(self, leaseId, txFee=pywaves.DEFAULT_LEASE_FEE, timestamp=0):
         if not self.privateKey:
-            logging.error('Private key required')
+            msg = 'Private key required'
+            logging.error(msg)
+            pywaves.throw_error(msg)
         elif not pywaves.OFFLINE and self.balance() < txFee:
-            logging.error('Insufficient Waves balance')
+            msg = 'Insufficient Waves balance'
+            logging.error(msg)
+            pywaves.throw_error(msg)
         else:
             if timestamp == 0:
                 timestamp = int(time.time() * 1000)
@@ -664,7 +704,9 @@ class Address(object):
     def createAlias(self, alias, txFee=pywaves.DEFAULT_ALIAS_FEE, timestamp=0):
         aliasWithNetwork = b'\x02' + str(pywaves.CHAIN_ID) + struct.pack(">H", len(alias)) + crypto.str2bytes(alias)
         if not self.privateKey:
-            logging.error('Private key required')
+            msg = 'Private key required'
+            logging.error(msg)
+            pywaves.throw_error(msg)
         else:
             if timestamp == 0:
                 timestamp = int(time.time() * 1000)

--- a/asset.py
+++ b/asset.py
@@ -111,7 +111,9 @@ class AssetPair(object):
             if limit > 0 and limit <= pywaves.MAX_WDF_REQUEST:
                 return self._getMarketData('/api/trades/', '%d' % limit)
             else:
-                return logging.error('Invalid request. Limit must be >0 and <= 100')
+                msg = 'Invalid request. Limit must be >0 and <= 100'
+                pywaves.throw_error(msg)
+                return logging.error(msg)
         elif len(args)==2:
             fromTimestamp = args[0]
             toTimestamp = args[1]
@@ -122,17 +124,23 @@ class AssetPair(object):
             timeframe = args[0]
             limit = args[1]
             if timeframe not in pywaves.VALID_TIMEFRAMES:
-                return logging.error('Invalid timeframe')
+                msg = 'Invalid timeframe'
+                pywaves.throw_error(msg)
+                return logging.error(msg)
             elif limit > 0 and limit <= pywaves.MAX_WDF_REQUEST:
                 return self._getMarketData('/api/candles', '%d/%d' % (timeframe, limit))
             else:
-                return logging.error('Invalid request. Limit must be >0 and <= 100')
+                msg = 'Invalid request. Limit must be >0 and <= 100'
+                pywaves.throw_error(msg)
+                return logging.error(msg)
         elif len(args)==3:
             timeframe = args[0]
             fromTimestamp = args[1]
             toTimestamp = args[2]
             if timeframe not in pywaves.VALID_TIMEFRAMES:
-                return logging.error('Invalid timeframe')
+                msg = 'Invalid timeframe'
+                pywaves.throw_error(msg)
+                return logging.error(msg)
             else:
                 return self._getMarketData('/api/candles', '%d/%d/%d' % (timeframe, fromTimestamp, toTimestamp))
 


### PR DESCRIPTION
You need to call pw.setThrowOnError(True) if you want to use it. And to call pw.setThrowOnError(False) to disable this behavior. This feature is disabled by default.