### PR TITLE
Proposal how to get more information from pywaves with less calls.

### DIFF
--- a/asset.py
+++ b/asset.py
@@ -4,7 +4,7 @@ import logging
 class Asset(object):
     def __init__(self, assetId, pywaves=pywaves):
         self.pywaves = pywaves
-        self.assetId='' if assetId == 'WAVES' else assetId
+        self.assetId='' if assetId == pywaves.DEFAULT_CURRENCY else assetId
         self.issuer = self.name = self.description = ''
         self.quantity = self.decimals = 0
         self.reissuable = False
@@ -22,21 +22,23 @@ class Asset(object):
                'description = %s\n' \
                'quantity = %d\n' \
                'decimals = %d\n' \
-               'reissuable = %s' % (self.status(), self.assetId, self.issuer, self.name, self.description, self.quantity, self.decimals, self.reissuable)
+               'reissuable = %s\n' \
+               'minSponsoredAssetFee = %s' % (self.status(), self.assetId, self.issuer, self.name, self.description, self.quantity, self.decimals, self.reissuable, self.minSponsoredAssetFee)
 
     __repr__ = __str__
 
     def status(self):
         if self.assetId!=pywaves.DEFAULT_CURRENCY:
             try:
-                req = self.pywaves.wrapper('/transactions/info/%s' % self.assetId)
-                if req['type'] == 3:
-                    self.issuer = req['sender']
+                req = self.pywaves.wrapper('/assets/details/%s' % self.assetId)
+                if req['assetId'] != None:
+                    self.issuer = req['issuer']
                     self.quantity = req['quantity']
                     self.decimals = req['decimals']
                     self.reissuable = req['reissuable']
                     self.name = req['name'].encode('ascii', 'ignore')
                     self.description = req['description'].encode('ascii', 'ignore')
+                    self.minSponsoredAssetFee = req['minSponsoredAssetFee']
                     return 'Issued'
             except:
                 pass

--- a/asset.py
+++ b/asset.py
@@ -8,6 +8,7 @@ class Asset(object):
         self.issuer = self.name = self.description = ''
         self.quantity = self.decimals = 0
         self.reissuable = False
+        self.minSponsoredAssetFee = None
         if self.assetId=='':
             self.quantity=100000000e8
             self.decimals=8


### PR DESCRIPTION
Pywaves used a call which never displayed if the asset was sponsored. There is a dedicated call which can provide this information.
This means instead of doing a call inside pywaves to get the details and then an external call to get the info if it's sponsored, one can now just use the pywaves call.
Below is example output for when it's sponsored, for when asset doesn't exist and for when not sponsored.

```
asset_create = '6Wet5PiBTS9NXbdGLXGG2giaEpanPzKWfKAga8dp5SkE'

print(py.Asset(asset_create))
print(py.Asset(asset_create).minSponsoredAssetFee)

asset_create = 'Aogujh1hRtA7bSt9gT57bH5qUy5SCSsa4Xqgd14nuSKB'
print(py.Asset(asset_create))
print(py.Asset(asset_create).minSponsoredAssetFee)

asset_create = 'Aogujh1hRtA7bSt9gT57bH5qUy5SCSsa4Xqgd14nuSKBq'
print(py.Asset(asset_create))
print(py.Asset(asset_create).minSponsoredAssetFee)


status = Issued
assetId = 6Wet5PiBTS9NXbdGLXGG2giaEpanPzKWfKAga8dp5SkE
issuer = 3XfnC4rR86JwhrWwR3yKc26PTBoRpUYJdXL
name = b'sponser'
description = b'spo ser'
quantity = 10000000000
decimals = 8
reissuable = True
minSponsoredAssetFee = 1
1
status = Issued
assetId = Aogujh1hRtA7bSt9gT57bH5qUy5SCSsa4Xqgd14nuSKB
issuer = 3XYqogMuCMnrmDbw2sKwjAHb1LZX3aiUH6o
name = b'Test token'
description = b'no description'
quantity = 600
decimals = 3
reissuable = True
minSponsoredAssetFee = None
None
status = None
assetId = Aogujh1hRtA7bSt9gT57bH5qUy5SCSsa4Xqgd14nuSKBq
issuer = 
name = 
description = 
quantity = 0
decimals = 0
reissuable = False
minSponsoredAssetFee = None
None
```