### PR TITLE
Oracleaddress objects mismatch

### DIFF
--- a/oracle.py
+++ b/oracle.py
@@ -6,7 +6,8 @@ class Oracle(object):
     def __init__(self, oracleAddress = None, seed = None, pywaves=pw):
         self.pw = pywaves
         if seed != None:
-            self.oracleAddress = self.pw.Address(seed=seed)
+            self.oracleAcc = self.pw.Address(seed=seed)
+            self.oracleAddress =  self.oracleAcc.address
         else:
             self.oracleAddress = oracleAddress
 
@@ -36,4 +37,4 @@ class Oracle(object):
             'value': dataEntry
         }]
 
-        return self.oracleAddress.dataTransaction(dataToStore,minimalFee=minimalFee)
+        return self.oracleAcc.dataTransaction(dataToStore,minimalFee=minimalFee)


### PR DESCRIPTION
when using a seed the oracle gave a mismatch since it's an address and you can't concatentate it with a string