### PR TITLE
Add Deployed Documentation Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PyWaves
-PyWaves is an object-oriented Python interface to the Waves blockchain platform.
+PyWaves is an object-oriented Python interface to the Waves blockchain platform. You can see the documentation [here](https://docs.contour.so/PyWaves/PyWaves/manual-2uakq9k0xu80000000000).
+
+
 
 ## Getting Started
 


### PR DESCRIPTION
Hi there,

I saw that the README is getting pretty long, and that it's starting to get difficult to navigate through everything. 

I split up the README and generated some relevant reference documentation, so that users can view it more easily 😄. Hope this is helpful in anyway. 

Also, if you find that the documentation isn't organized the way you want, you can easily make edits by dragging elements on the sidebar or just clicking the `Edit` button!